### PR TITLE
Mkdocs Documentation Website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ node_modules/
 *.njsproj
 *.sln
 *.sw?
+
+# documentation
+docs/site/

--- a/README.md
+++ b/README.md
@@ -71,3 +71,27 @@ The backend follows a modular structure, keeping all structures related to a cer
 * utils
   * ***.errors.ts** - Defines custom errors thrown in the service, configured to be converted to an HTTP response.
   * ***.validator.ts** - Contains input validation logic and models for the given feature.
+
+## Documentation Website
+We will be using MkDocs for documentation. To run the documentation server, you need to do a few
+things
+
+### Setup 
+1. Install MkDocs and required plugins:
+```bash
+pip install mkdocs mkdocs-material pymdown-extensions 
+```
+2. Run documentation server:
+```bash
+cd docs
+mkdocs serve
+```
+3. View the site on: http://127.0.0.1:8000/ 
+
+### Building the state documentation
+To build the static site:
+```bash
+cd docs
+mkdocs build
+```
+The static site is built in the ```docs/site``` directory

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The backend follows a modular structure, keeping all structures related to a cer
 
 ## Documentation Website
 We will be using MkDocs for documentation. To run the documentation server, you need to do a few
-things
+things.
 
 ### Setup 
 1. Install MkDocs and required plugins:
@@ -88,10 +88,10 @@ mkdocs serve
 ```
 3. View the site on: http://127.0.0.1:8000/ 
 
-### Building the state documentation
+### Building static documentation
 To build the static site:
 ```bash
 cd docs
 mkdocs build
 ```
-The static site is built in the ```docs/site``` directory
+The static site is built in the ```docs/site``` directory.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,49 @@
+site_name: MedMatch Documentation
+docs_dir: src
+theme:
+  name: material
+  features:
+    - content.code.copy
+    - content.code.select
+    - content.code.annotate
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default 
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+  icon:
+    annotation: material/plus-circle
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - pymdownx.superfences
+
+nav:
+  - Home: index.md
+  - API: api_overview.md
+  - File Structure: file_structure.md
+  - Onboarding: onboarding.md

--- a/docs/src/api_overview.md
+++ b/docs/src/api_overview.md
@@ -1,0 +1,1 @@
+# API Documentation/Overview

--- a/docs/src/file_structure.md
+++ b/docs/src/file_structure.md
@@ -1,0 +1,1 @@
+# File Structure

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,1 @@
+# MedMatch Project Documentation

--- a/docs/src/onboarding.md
+++ b/docs/src/onboarding.md
@@ -1,0 +1,1 @@
+# Onboarding 

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "nodemon --exec tsx src/index.ts",
     "test": "jest --verbose",
-    "test:filter": "jest --verbose --testNamePattern"
+    "test:filter": "jest --verbose --testNamePattern",
+    "docs:serve": "cd docs && mkdocs serve",
+    "docs:build": "cd docs && mkdocs build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Created a simple Mkdocs documentation website with some pre-defined links. Also added a section to the readme about how to get the site going, edited the package.json file to include the npm scripts for convenience, and added "docs/site" to the .gitignore so that when you build the site locally, it won't be tracked by git. 