### PR TITLE
auth integration and also making sign in and signup nav bar buttons work

### DIFF
--- a/client/src/app/api/auth/[...nextauth]/route.ts
+++ b/client/src/app/api/auth/[...nextauth]/route.ts
@@ -31,7 +31,7 @@ export const authOptions: AuthOptions = {
         let user: User;
         try {
           const { data: body } = await authClient.post<AccountWithTokens>(
-            "/api/accounts/login",
+            "/accounts/login",
             {
               email,
               password,
@@ -88,7 +88,7 @@ export const authOptions: AuthOptions = {
         }
 
         // Refresh token
-        const { data: body } = await authClient.post<Tokens>("api/accounts/token", {
+        const { data: body } = await authClient.post<Tokens>("/accounts/token", {
           refreshToken: token.refreshToken,
         });
 

--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -1,8 +1,53 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { logout } from "@/services/authService";
+
 export default function Profile() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+    }
+  }, [status, router]);
+
+  const handleLogout = async () => {
+    try {
+      await logout("/login");
+    } catch (error) {
+      console.error("Logout error:", error);
+    }
+  };
+
+  if (status === "loading") {
+    return <div>Loading...</div>;
+  }
+
+  if (status === "unauthenticated") {
+    return <div>Redirecting to login...</div>;
+  }
+
   return (
     <>
-      <h1 className="text-4xl font-semibold mb-4">Hello John Doe</h1>
-      <div className="grid grid-cols-3 gap-4">
+      <h1 className="text-4xl font-semibold mb-4">Hello {session?.user?.email}</h1>
+      <div className="mb-4">
+        <p><strong>Email:</strong> {session?.user?.email}</p>
+        <p><strong>Access Token Available:</strong> {session?.accessToken ? "Yes" : "No"}</p>
+        {session?.accessToken && (
+          <p><strong>Access Token (first 50 chars):</strong> {session.accessToken.substring(0, 50)}...</p>
+        )}
+      </div>
+      <button 
+        onClick={handleLogout}
+        className="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600"
+      >
+        Logout
+      </button>
+      <div className="mt-8 grid grid-cols-3 gap-4">
         {[...Array(5).keys()].map((i) => (
           <div
             key={i}

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,10 +1,23 @@
+"use client";
+
 import Link from "next/link";
 import Image from "next/image";
+import { useSession } from "next-auth/react";
 import title from "@/assets/medmatch_.svg";
-import { Button } from "@/components/ui/button"
-
+import { Button } from "@/components/ui/button";
+import { logout } from "@/services/authService";
 
 function Navbar() {
+  const { data: session, status } = useSession();
+
+  const handleLogout = async () => {
+    try {
+      await logout("/");
+    } catch (error) {
+      console.error("Logout error:", error);
+    }
+  };
+
   return (
     <div className="bg-[#ffffff] shadow-md flex justify-between items-center py-2 px-4 gap-8 pl-10 pr-10">
       <div className="flex items-center">
@@ -18,14 +31,40 @@ function Navbar() {
         </Link>
       </div>
       <ul className="flex items-center p-0 m-0 list-none gap-4">
-        <li>
-          <Link href="/" className="text-primary-blue text-lg pr-10 font-semibold">Sign In</Link>
-        </li>
-        <li>
-          <Button className="w-36 h-12 text-lg font-semibold bg-primary-blue hover:bg-[#ffffff] hover:text-primary-blue hover:outline hover:outline-primary-blue hover:outline-[2]">
-            <span>Sign Up</span>
-          </Button>
-        </li>
+        {status === "loading" ? (
+          <li>Loading...</li>
+        ) : session ? (
+          <>
+            <li>
+              <Link href="/profile" className="text-primary-blue text-lg pr-10 font-semibold">
+                Profile
+              </Link>
+            </li>
+            <li>
+              <Button 
+                onClick={handleLogout}
+                className="w-36 h-12 text-lg font-semibold bg-primary-blue hover:bg-[#ffffff] hover:text-primary-blue hover:outline hover:outline-primary-blue hover:outline-[2]"
+              >
+                <span>Log Out</span>
+              </Button>
+            </li>
+          </>
+        ) : (
+          <>
+            <li>
+              <Link href="/login" className="text-primary-blue text-lg pr-10 font-semibold">
+                Sign In
+              </Link>
+            </li>
+            <li>
+              <Button className="w-36 h-12 text-lg font-semibold bg-primary-blue hover:bg-[#ffffff] hover:text-primary-blue hover:outline hover:outline-primary-blue hover:outline-[2]">
+                <Link href="/signup">
+                  <span>Sign Up</span>
+                </Link>
+              </Button>
+            </li>
+          </>
+        )}
       </ul>
     </div>
   );

--- a/client/src/lib/authClient.ts
+++ b/client/src/lib/authClient.ts
@@ -17,7 +17,7 @@ import axios from "axios";
  */
 const authClient = axios.create({
   withCredentials: true,
-  baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL!}/api`,
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:4000/api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -1,8 +1,8 @@
 import { authClient } from "@/lib/authClient";
 import { signIn, signOut } from "next-auth/react";
-import { AccountWithTokens, CreateAccountInput } from "@/types/dto/accountDto";
+import { AccountWithTokens, CreateAccountInput, SignupInput } from "@/types/dto/accountDto";
 
-const withBase = (path: string) => `/api/auth${path}`;
+const withBase = (path: string) => `/accounts${path}`;
 
 /**
  * Authenticates a user based on email and password, adding the user to the session.
@@ -44,7 +44,7 @@ async function login(
  * @throws An `AxiosError` if there is a login conflict. Generic error if the NextAuth request fails.
  */
 async function signup(
-  accountData: CreateAccountInput,
+  accountData: SignupInput,
   callbackUrl: string | null = "/"
 ): Promise<void> {
   await authClient.post<AccountWithTokens>(withBase("/signup"), accountData);

--- a/client/src/types/dto/accountDto.ts
+++ b/client/src/types/dto/accountDto.ts
@@ -16,3 +16,12 @@ export type CreateAccountInput = {
   email: string,
   password: string
 }
+
+export type SignupInput = {
+  first: string,
+  last: string,
+  phone: string,
+  birthday: string,
+  email: string,
+  password: string
+}


### PR DESCRIPTION
### Integrate Frontend Auth Service with Login and Signup Pages
Integrated the existing auth service with login and signup forms to enable end-to-end authentication. Added proper error handling, loading states, and session management.

Changes
 - Auth Service: Fixed API endpoints to use /accounts instead of /api/auth and added SignupInput type for extended signup data
 - Login/Signup Pages: Connected forms to auth service functions with error handling and loading states
 - Profile Page: Made authentication-aware with session display and logout functionality
 - Navbar: Added dynamic navigation based on auth status (Profile/Logout vs Sign In/Sign Up)
 - NextAuth Config: Fixed endpoint paths and ensured access tokens are exposed in session

Users can now sign up/login through the forms, which calls the backend API to generate JWT tokens. Refresh tokens are stored in httpOnly cookies, access tokens are available via NextAuth session, and automatic token refresh is handled. Logout clears session and redirects appropriately.

Closes #12 